### PR TITLE
PRD-5327 - Not implementing Serializable prevents copy&paste of reports 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.iml
+*.idea
+dist
+bin

--- a/src/com/debortoliwines/openerp/reporting/di/OpenERPConfiguration.java
+++ b/src/com/debortoliwines/openerp/reporting/di/OpenERPConfiguration.java
@@ -19,6 +19,7 @@ package com.debortoliwines.openerp.reporting.di;
  *   Copyright 2012 De Bortoli Wines Pty Limited (Australia)
  */
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
@@ -28,7 +29,7 @@ import java.util.ArrayList;
  * @since  Jan 5, 2012
  *
  */
-public class OpenERPConfiguration implements Cloneable{
+public class OpenERPConfiguration implements Cloneable, Serializable {
 
   private String hostName;
   private int portNumber;

--- a/src/com/debortoliwines/openerp/reporting/di/OpenERPFieldInfo.java
+++ b/src/com/debortoliwines/openerp/reporting/di/OpenERPFieldInfo.java
@@ -21,6 +21,8 @@ package com.debortoliwines.openerp.reporting.di;
 
 import com.debortoliwines.openerp.api.Field.FieldType;
 
+import java.io.Serializable;
+
 /**
  * Holds available and selected field information.
  * An instance is unique by:
@@ -32,7 +34,7 @@ import com.debortoliwines.openerp.api.Field.FieldType;
  * @author Pieter van der Merwe
  * @since  Jan 5, 2012
  */
-public class OpenERPFieldInfo implements Cloneable{
+public class OpenERPFieldInfo implements Cloneable, Serializable {
 
   private final String modelName;
   private final String fieldName;

--- a/src/com/debortoliwines/openerp/reporting/di/OpenERPFilterInfo.java
+++ b/src/com/debortoliwines/openerp/reporting/di/OpenERPFilterInfo.java
@@ -19,13 +19,15 @@ package com.debortoliwines.openerp.reporting.di;
  *   Copyright 2012 De Bortoli Wines Pty Limited (Australia)
  */
 
+import java.io.Serializable;
+
 /**
  * Stores filter information.  The key that links a filter to a table is the modelPath and instanceNumber.
  * The modelPath and instanceNumber are used later by OpenERPQueryItem to link a filter to a query call
  * @author Pieter van der Merwe
  * @since  Jan 5, 2012
  */
-public class OpenERPFilterInfo implements Cloneable{
+public class OpenERPFilterInfo implements Cloneable, Serializable {
 
   private String modelPath;
   private int instanceNum;


### PR DESCRIPTION
Original case: http://jira.pentaho.com/browse/PRD-5327?filter=12774

To implement Copy&Paste in a safe way, PRD serializes reports and elements. Reports that contain a OpenERP data-source are not serializable, as the OpenERPConfiguration and associated classes are not serializable. PRD does not care about long-term storage, we just want to get data in and out of the system clipboard. So short-term serialization is fine. 

The fix is simple: Implement Serializable for the OpenERPConfiguration object and its contained objects. All properties should be safely serializable once they implement the java.io.Serializable interface. 

Only the OpenERPFilterInfo has one non-serializable field for the "value". But from the code it seems as it will only ever contain strings, or maybe other primitive objects. It seems OK to just declare that class serializable and hope that no user ever puts something in there that is not serializable.
